### PR TITLE
Fix file upload failure in frontend

### DIFF
--- a/frontend/src/api/files.ts
+++ b/frontend/src/api/files.ts
@@ -32,7 +32,6 @@ export const filesApi = {
         formData.append('file', file)
         return api.post<FileUploadResponse>('/files', formData, {
             params: channelId ? { channel_id: channelId } : undefined,
-            headers: { 'Content-Type': 'multipart/form-data' },
             onUploadProgress: onProgress,
         })
     },


### PR DESCRIPTION
Fixes file upload issue caused by manual `Content-Type` header setting in frontend API client.

---
*PR created automatically by Jules for task [17520992741799153682](https://jules.google.com/task/17520992741799153682) started by @senolcolak*