### PR TITLE
Fix MiroTalk integration API endpoints

### DIFF
--- a/backend/src/api/admin.rs
+++ b/backend/src/api/admin.rs
@@ -19,6 +19,7 @@ use crate::models::{
     CreateRetentionPolicy,
     CreateSsoConfig,
     MiroTalkConfig,
+    MiroTalkStats,
     Permission,
     RetentionPolicy,
     ServerConfig,
@@ -29,7 +30,7 @@ use crate::models::{
     TeamMemberResponse,
     UpdateChannel,
 };
-use crate::services::mirotalk::{MiroTalkClient, MiroTalkStats};
+use crate::services::mirotalk::MiroTalkClient;
 use sqlx::FromRow;
 
 /// Build admin routes

--- a/backend/src/models/mirotalk.rs
+++ b/backend/src/models/mirotalk.rs
@@ -39,3 +39,25 @@ impl MiroTalkConfig {
         self.mode != MiroTalkMode::Disabled && !self.base_url.is_empty()
     }
 }
+
+// API Response Models
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct MiroTalkStats {
+    pub peers: Option<i32>,
+    pub rooms: Option<i32>,
+    pub active_rooms: Option<Vec<String>>,
+    // Add other fields as needed based on actual API response
+    #[serde(flatten)]
+    pub extra: serde_json::Value,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct MeetingsResponse {
+    pub meetings: Vec<serde_json::Value>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct CreateMeetingResponse {
+    pub meeting: String, // The URL
+}


### PR DESCRIPTION
This PR fixes the MiroTalk integration which was reported as "not working at all". The investigation revealed incorrect API endpoints were being used for both SFU and P2P modes.

Key changes:
1.  **Endpoint Corrections**:
    *   Changed "Active Meetings" endpoint from `/api/v1/meeting` (SFU) / `/api/v1/rooms` (P2P) to `/api/v1/meetings` for both, as per official documentation.
    *   Changed P2P meeting creation to use `POST /api/v1/meeting` instead of client-side URL string concatenation.

2.  **Robustness**:
    *   Added proper JSON response parsing for meetings list using `MeetingsResponse` struct.
    *   Added handling for both string-based and object-based meeting lists in the response.
    *   Improved error logging for external service failures.

3.  **Refactoring**:
    *   Moved API response structs to `backend/src/models/mirotalk.rs`.

Testing:
*   Verified logic with updated unit tests for URL construction.
*   Compilation checked.


---
*PR created automatically by Jules for task [17439287069498274045](https://jules.google.com/task/17439287069498274045) started by @senolcolak*