### PR TITLE
Restrict team creation permissions and update integration tests

### DIFF
--- a/backend/src/api/teams.rs
+++ b/backend/src/api/teams.rs
@@ -82,7 +82,7 @@ async fn create_team(
     auth: AuthUser,
     Json(payload): Json<CreateTeam>,
 ) -> Result<Json<Team>, AppError> {
-    if !auth.has_permission(&permissions::TEAM_CREATE) {
+    if !auth.has_permission(&permissions::TEAM_MANAGE) {
         return Err(AppError::Forbidden(
             "Missing permission to create teams".to_string(),
         ));

--- a/backend/src/auth/policy.rs
+++ b/backend/src/auth/policy.rs
@@ -156,7 +156,6 @@ impl Role {
         // Basic permissions for regular users
         permissions.insert(USER_READ);
         permissions.insert(USER_UPDATE); // Own profile only
-        permissions.insert(TEAM_CREATE);
         permissions.insert(TEAM_READ);
         permissions.insert(CHANNEL_READ);
         permissions.insert(CHANNEL_CREATE); // Can create channels
@@ -316,7 +315,7 @@ mod tests {
     fn test_member_limited_permissions() {
         let member = Role::member();
 
-        assert!(member.has_permission(&TEAM_CREATE));
+        assert!(!member.has_permission(&TEAM_CREATE));
         assert!(member.has_permission(&POST_CREATE));
         assert!(member.has_permission(&CHANNEL_READ));
         assert!(!member.has_permission(&USER_MANAGE));
@@ -346,7 +345,7 @@ mod tests {
 
         assert_eq!(
             PolicyEngine::check_permission("member", &TEAM_CREATE),
-            AuthzResult::Allow
+            AuthzResult::Deny("Permission denied")
         );
 
         assert!(matches!(

--- a/backend/tests/api_categories.rs
+++ b/backend/tests/api_categories.rs
@@ -48,7 +48,15 @@ async fn test_sidebar_categories() {
         .unwrap()
         .to_string();
     let user_info: serde_json::Value = login_res.json().await.unwrap();
-    let _user_id = user_info["id"].as_str().unwrap();
+    let user_id = user_info["id"].as_str().unwrap();
+
+    // Update user role to org_admin to allow team creation
+    let user_uuid = parse_mm_or_uuid(user_id).expect("invalid mm user id");
+    sqlx::query("UPDATE users SET role = 'org_admin' WHERE id = $1")
+        .bind(user_uuid)
+        .execute(&app.db_pool)
+        .await
+        .expect("Failed to update user role");
 
     // 2. Create a team (v1)
     let team_data = json!({
@@ -240,6 +248,13 @@ async fn get_categories_backfills_orphaned_channels() {
     let user_info: serde_json::Value = login_res.json().await.expect("invalid login body");
     let user_id = user_info["id"].as_str().expect("missing user id");
     let user_uuid = parse_mm_or_uuid(user_id).expect("invalid mm user id");
+
+    // Update user role to org_admin to allow team creation
+    sqlx::query("UPDATE users SET role = 'org_admin' WHERE id = $1")
+        .bind(user_uuid)
+        .execute(&app.db_pool)
+        .await
+        .expect("Failed to update user role");
 
     let team_data = json!({
         "name": "cat-orphan-team",

--- a/backend/tests/api_permissions.rs
+++ b/backend/tests/api_permissions.rs
@@ -7,7 +7,7 @@ use crate::common::spawn_app;
 mod common;
 
 #[tokio::test]
-async fn member_can_create_team() {
+async fn member_cannot_create_team() {
     let app = spawn_app().await;
     let org_id = insert_org(&app, "Permission Org").await;
     let (token, _user_id) =
@@ -25,13 +25,7 @@ async fn member_can_create_team() {
         .await
         .expect("team create request should complete");
 
-    assert_eq!(response.status(), StatusCode::OK);
-    let body = response
-        .json::<serde_json::Value>()
-        .await
-        .expect("team create response should be JSON");
-    assert_eq!(body["name"], "unauthorized-team");
-    assert_eq!(body["display_name"], "Unauthorized Team");
+    assert_eq!(response.status(), StatusCode::FORBIDDEN);
 }
 
 #[tokio::test]


### PR DESCRIPTION
This PR reverts the team creation permission relaxation and updates the integration tests to comply with the restricted permission model where regular members cannot create teams.

---
*PR created automatically by Jules for task [351389847763851100](https://jules.google.com/task/351389847763851100) started by @senolcolak*