### PR TITLE
Fix slash command error status and enable lifecycle test

### DIFF
--- a/backend/src/api/integrations.rs
+++ b/backend/src/api/integrations.rs
@@ -1066,14 +1066,9 @@ pub async fn execute_command_internal(
 
         // Validate slash command URL to prevent SSRF
         if !is_valid_callback_url(&cmd.url) {
-            return Ok(CommandResponse {
-                response_type: "ephemeral".to_string(),
-                text: "Command URL is not valid or points to an internal address".to_string(),
-                username: None,
-                icon_url: None,
-                goto_location: None,
-                attachments: None,
-            });
+            return Err(AppError::BadRequest(
+                "Command URL is not valid or points to an internal address".to_string(),
+            ));
         }
 
         // Execute external command (HTTP POST)

--- a/backend/tests/api_integrations.rs
+++ b/backend/tests/api_integrations.rs
@@ -6,7 +6,6 @@ use serde_json::Value;
 mod common;
 
 #[tokio::test]
-#[ignore] // TODO: Test expects 500 when webhook fails, but getting 200. Needs investigation.
 async fn test_slash_command_lifecycle() {
     let app = spawn_app().await;
 
@@ -180,5 +179,5 @@ async fn test_slash_command_lifecycle() {
         .await
         .expect("Failed to execute custom command");
 
-    assert_eq!(500, exec_res.status().as_u16());
+    assert_eq!(400, exec_res.status().as_u16());
 }


### PR DESCRIPTION
This PR addresses an issue where the `test_slash_command_lifecycle` was failing and ignored because it expected a non-200 status code when a slash command URL was blocked by SSRF protection. The backend now correctly returns `400 Bad Request` in this case, and the test has been updated and re-enabled. Additionally, I've reviewed the newly added Terms of Service feature, which follows the project's architectural patterns.

---
*PR created automatically by Jules for task [8667073158285634314](https://jules.google.com/task/8667073158285634314) started by @senolcolak*