### PR TITLE
docs: clarify Node.js 24 frontend requirement

### DIFF
--- a/docs/development/contributing.md
+++ b/docs/development/contributing.md
@@ -10,7 +10,7 @@
 ### Prerequisites
 
 - **Rust** 1.80+ with `cargo`
-- **Node.js** 24+ with `npm` for frontend development. Node.js 20 or older will fail the frontend install/build because `frontend/package.json` requires `>=24.0.0`; upgrade via the [Node.js downloads](https://nodejs.org/en/download) page or a version manager such as [nvm](https://github.com/nvm-sh/nvm).
+- **Node.js** 24+ with `npm` for frontend development. Any Node.js version below 24 will fail the frontend install/build because `frontend/package.json` requires `>=24.0.0`; upgrade via the [Node.js downloads](https://nodejs.org/en/download) page or a version manager such as [nvm](https://github.com/nvm-sh/nvm).
 - **PostgreSQL** 16+
 - **Redis** 7+
 - **S3-compatible storage** (RustFS/MinIO for local dev)

--- a/docs/development/contributing.md
+++ b/docs/development/contributing.md
@@ -10,7 +10,7 @@
 ### Prerequisites
 
 - **Rust** 1.80+ with `cargo`
-- **Node.js** 20+ with `npm`
+- **Node.js** 24+ with `npm` for frontend development. Node.js 20 or older will fail the frontend install/build because `frontend/package.json` requires `>=24.0.0`; upgrade via the [Node.js downloads](https://nodejs.org/en/download) page or a version manager such as [nvm](https://github.com/nvm-sh/nvm).
 - **PostgreSQL** 16+
 - **Redis** 7+
 - **S3-compatible storage** (RustFS/MinIO for local dev)

--- a/docs/development/local-setup.md
+++ b/docs/development/local-setup.md
@@ -54,9 +54,11 @@ You can run the backend locally while keeping infrastructure services (DB, Redis
 
 ### Frontend Development
 1.  Stop the `frontend` container if running: `docker compose stop frontend`
-2.  Run npm locally:
+2.  Use Node.js 24 or newer. Node.js 20 or older will fail the frontend install/build because `frontend/package.json` requires `>=24.0.0`; upgrade via the [Node.js downloads](https://nodejs.org/en/download) page or [nvm](https://github.com/nvm-sh/nvm).
+3.  Run npm locally:
     ```bash
     cd frontend
+    npm ci
     npm run dev
     ```
     *Access at [http://localhost:5173](http://localhost:5173).*

--- a/docs/development/local-setup.md
+++ b/docs/development/local-setup.md
@@ -54,7 +54,7 @@ You can run the backend locally while keeping infrastructure services (DB, Redis
 
 ### Frontend Development
 1.  Stop the `frontend` container if running: `docker compose stop frontend`
-2.  Use Node.js 24 or newer. Node.js 20 or older will fail the frontend install/build because `frontend/package.json` requires `>=24.0.0`; upgrade via the [Node.js downloads](https://nodejs.org/en/download) page or [nvm](https://github.com/nvm-sh/nvm).
+2.  Use Node.js 24 or newer. Any Node.js version below 24 will fail the frontend install/build because `frontend/package.json` requires `>=24.0.0`; upgrade via the [Node.js downloads](https://nodejs.org/en/download) page or [nvm](https://github.com/nvm-sh/nvm).
 3.  Run npm locally:
     ```bash
     cd frontend

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -2,6 +2,10 @@
 
 Vue 3 + TypeScript + Vite SPA for RustChat.
 
+## Requirements
+
+- Node.js 24+ with `npm`. Node.js 20 or older will fail install/build because this workspace requires `>=24.0.0`; upgrade via the [Node.js downloads](https://nodejs.org/en/download) page or [nvm](https://github.com/nvm-sh/nvm).
+
 ## Commands
 
 ```bash

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -4,7 +4,7 @@ Vue 3 + TypeScript + Vite SPA for RustChat.
 
 ## Requirements
 
-- Node.js 24+ with `npm`. Node.js 20 or older will fail install/build because this workspace requires `>=24.0.0`; upgrade via the [Node.js downloads](https://nodejs.org/en/download) page or [nvm](https://github.com/nvm-sh/nvm).
+- Node.js 24+ with `npm`. Any Node.js version below 24 will fail install/build because this workspace requires `>=24.0.0`; upgrade via the [Node.js downloads](https://nodejs.org/en/download) page or [nvm](https://github.com/nvm-sh/nvm).
 
 ## Commands
 


### PR DESCRIPTION
## Summary
- update contributor prerequisites to require Node.js 24+ for frontend work
- add the Node.js 24 requirement to local frontend setup and the frontend README
- note that Node.js 20 or older can fail install/build and link upgrade options

## Testing
- git diff --check

Closes #94