### PR TITLE
fix: improve empty-state copy for channels

### DIFF
--- a/frontend/src/components/layout/ChannelSidebar.vue
+++ b/frontend/src/components/layout/ChannelSidebar.vue
@@ -639,7 +639,7 @@ async function handleLeaveTeam() {
             
             <!-- Empty Category State -->
             <div v-if="cat.channels.length === 0" class="px-8 py-3 text-xs text-text-3 italic">
-              No channels
+              No channels in this category yet
             </div>
           </div>
         </div>

--- a/frontend/src/views/main/ChannelView.vue
+++ b/frontend/src/views/main/ChannelView.vue
@@ -266,11 +266,20 @@ function handleKeydown(e: KeyboardEvent) {
             class="relative flex flex-col flex-1 min-w-0 z-10 bg-transparent transition-all duration-300"
             :class="{ 'mr-0': !uiStore.isRhsOpen }"
           >
-              <!-- No Channel Selected -->
+              <!-- No Channel Selected / No Channels Exist -->
               <div v-if="!currentChannel" class="flex-1 flex items-center justify-center text-slate-500">
-                  <div class="text-center">
-                      <p class="text-lg">Select a channel to start messaging</p>
-                      <p class="text-sm mt-2">Choose a channel from the sidebar</p>
+                  <div class="text-center max-w-sm px-4">
+                    <template v-if="channelStore.channels.length === 0">
+                      <p class="text-lg font-medium text-slate-600">No channels yet</p>
+                      <p class="text-sm mt-2">
+                        Get started by creating a channel or browsing existing ones —
+                        use the <span class="font-semibold">+</span> button in the sidebar.
+                      </p>
+                    </template>
+                    <template v-else>
+                      <p class="text-lg font-medium text-slate-600">No channel selected</p>
+                      <p class="text-sm mt-2">Choose a channel from the sidebar to start messaging.</p>
+                    </template>
                   </div>
               </div>
               


### PR DESCRIPTION
## Summary

Improves the empty-state messaging shown to users when no channel is selected or no channels exist yet.

### Changes

- **`ChannelView.vue`**: The empty-state now has two distinct cases:
  - **No channels exist yet** — shows "No channels yet" with a friendly prompt to use the **+** button in the sidebar to create or browse channels.
  - **Channels exist but none selected** — shows "No channel selected" with a nudge to pick one from the sidebar.
- **`ChannelSidebar.vue`**: Per-category empty label updated from the terse "No channels" → "No channels in this category yet" for clarity.

## Testing

- Log in to a fresh workspace with no channels → verify the new "No channels yet" message with the + button hint.
- Log in to a workspace with channels but navigate to a non-channel route → verify "No channel selected" message.
- Collapse/remove all channels from a category → verify the per-category label.

Closes #93