### PR TITLE
ci: replace legacy aggregators with single CI Complete check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -323,85 +323,28 @@ EOF
         working-directory: ./backend
         run: cargo build --release
 
-  # ============ Required Status Check Aggregators ============
-  # These jobs always run to satisfy branch protection rules that expect
-  # the legacy status check names from the old workflow structure.
+  # ============ Status Check Aggregator ============
+  # This job always runs so branch protection can require a single stable
+  # check name regardless of which individual jobs are conditionally skipped.
 
-  test:
-    name: Test
+  ci-complete:
+    name: CI Complete
     runs-on: ubuntu-latest
-    needs: [detect-changes, backend-check, frontend-check, push-proxy-check]
+    needs: [detect-changes, backend-check, frontend-check, push-proxy-check, docker-validate, build-release]
     if: always()
     steps:
-      - name: Fail if change detection failed
+      - name: Check change detection
         if: needs.detect-changes.result == 'failure'
         run: echo "Change detection failed" >&2 && exit 1
 
-      - name: Report skipped tests
-        if: needs.detect-changes.outputs.backend != 'true' && needs.detect-changes.outputs.frontend != 'true' && needs.detect-changes.outputs.push-proxy != 'true'
-        run: echo "No code changes detected; tests skipped."
-
-      - name: Require test success
-        if: needs.detect-changes.outputs.backend == 'true' || needs.detect-changes.outputs.frontend == 'true' || needs.detect-changes.outputs.push-proxy == 'true'
+      - name: Verify all checks passed
         run: |
-          for job in backend-check frontend-check push-proxy-check; do
+          for job in backend-check frontend-check push-proxy-check docker-validate build-release; do
             result="${{ needs[job].result }}"
-            echo "$job result: $result"
+            echo "$job: $result"
             if [ "$result" = "failure" ]; then
               echo "$job failed" >&2
               exit 1
             fi
           done
-          echo "All tests passed."
-
-  build:
-    name: Build
-    runs-on: ubuntu-latest
-    needs: [detect-changes, backend-check, build-release]
-    if: always()
-    steps:
-      - name: Fail if change detection failed
-        if: needs.detect-changes.result == 'failure'
-        run: echo "Change detection failed" >&2 && exit 1
-
-      - name: Report skipped build
-        if: needs.detect-changes.outputs.backend != 'true' && needs.detect-changes.outputs.scripts != 'true'
-        run: echo "No backend changes detected; build skipped."
-
-      - name: Require build success
-        if: needs.detect-changes.outputs.backend == 'true' || needs.detect-changes.outputs.scripts == 'true'
-        run: |
-          backend_result="${{ needs['backend-check'].result }}"
-          build_result="${{ needs['build-release'].result }}"
-          echo "backend-check result: $backend_result"
-          echo "build-release result: $build_result"
-          if [ "$backend_result" = "failure" ] || [ "$build_result" = "failure" ]; then
-            echo "Build pipeline failed" >&2
-            exit 1
-          fi
-          echo "Build passed."
-
-  cargo-check-test:
-    name: cargo check + test
-    runs-on: ubuntu-latest
-    needs: [detect-changes, backend-check]
-    if: always()
-    steps:
-      - name: Fail if change detection failed
-        if: needs.detect-changes.result == 'failure'
-        run: echo "Change detection failed" >&2 && exit 1
-
-      - name: Report skipped backend check
-        if: needs.detect-changes.outputs.backend != 'true' && needs.detect-changes.outputs.scripts != 'true'
-        run: echo "No backend changes detected; cargo check + test skipped."
-
-      - name: Require backend check success
-        if: needs.detect-changes.outputs.backend == 'true' || needs.detect-changes.outputs.scripts == 'true'
-        run: |
-          result="${{ needs['backend-check'].result }}"
-          echo "backend-check result: $result"
-          if [ "$result" = "failure" ]; then
-            echo "Backend check failed" >&2
-            exit 1
-          fi
-          echo "cargo check + test passed."
+          echo "All checks passed or were skipped."


### PR DESCRIPTION
Removes the three legacy status-check aggregators (Test, Build, cargo check + test) and replaces them with one clean `CI Complete` aggregator.

**Why:** Branch protection was updated to require new job names, making the legacy aggregators dead weight.

**How it works:**
- Always runs (`if: always()`)
- Depends on all conditional jobs
- Passes if jobs succeeded or were skipped (no relevant changes)
- Fails if any job failed or change detection itself failed

**Action required after merge:** Update branch protection on `main` to require only `CI Complete` — never individual conditional jobs directly.