### PR TITLE
fix(ci): grant scorecard contents permission

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -14,6 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
+      contents: read
       security-events: write
       id-token: write
     steps:


### PR DESCRIPTION
## Summary
- grant contents: read to the OpenSSF Scorecard job-level permissions so checkout and scorecard can read the repository

## Testing
- python3 YAML parse for .github/workflows/scorecard.yml
- git diff --check