### PR TITLE
fix(ci): pin scorecard action to valid ref

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -23,7 +23,7 @@ jobs:
           persist-credentials: false
 
       - name: Run Scorecard
-        uses: ossf/scorecard-action@f49ab50085bc1ac11c253e99c65b5ca940b5a0d4 # v2.4.1
+        uses: ossf/scorecard-action@ea651e62978af7915d09fe2e282747c798bf2dab # v2.4.1
         with:
           results_file: results.sarif
           results_format: sarif


### PR DESCRIPTION
## Summary
- replace the invalid OpenSSF Scorecard action SHA with the valid v2.4.1 tag commit
- keep the existing contents/security-events/id-token permissions from PR #136

## Verification
- git ls-remote confirmed ossf/scorecard-action v2.4.1 resolves to ea651e62978af7915d09fe2e282747c798bf2dab
- python3 YAML parse for .github/workflows/scorecard.yml
- git diff --check