### PR TITLE
fix(ci): skip merge commits in DCO check

### DIFF
--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -36,6 +36,12 @@ jobs:
 
           commits_missing_signoff=0
           while IFS= read -r commit; do
+            parent_count="$(git rev-list --parents -n 1 "${commit}" | wc -w)"
+            if [[ "${parent_count}" -gt 2 ]]; then
+              echo "Skipping merge commit ${commit}."
+              continue
+            fi
+
             if ! git log -1 --format="%B" "${commit}" | grep -q "^Signed-off-by:"; then
               echo "::error::Commit ${commit} is missing DCO sign-off."
               git log -1 --oneline "${commit}"


### PR DESCRIPTION
## Summary
- skip merge commits in the DCO workflow so GitHub-generated merge commits do not fail push checks
- continue enforcing Signed-off-by on normal commits

## Verification
- parsed .github/workflows/dco.yml as YAML
- git diff --check
- simulated the failing range from the log: 04bdf9b..HEAD skips abd1245 and validates the normal signed commit