### PR TITLE
fix(ci): pin scorecard action to release commit

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -23,7 +23,7 @@ jobs:
           persist-credentials: false
 
       - name: Run Scorecard
-        uses: ossf/scorecard-action@ea651e62978af7915d09fe2e282747c798bf2dab # v2.4.1
+        uses: ossf/scorecard-action@f49aabe0b5af0936a0987cfb85d86b75731b0186 # v2.4.1
         with:
           results_file: results.sarif
           results_format: sarif


### PR DESCRIPTION
## Summary
- replace the OpenSSF Scorecard annotated tag object SHA with the peeled release commit SHA
- keeps the action pinned while satisfying Scorecard publish verification

## Verification
- git ls-remote confirmed refs/tags/v2.4.1^{} = f49aabe0b5af0936a0987cfb85d86b75731b0186
- parsed .github/workflows/scorecard.yml as YAML
- git diff --check