### PR TITLE
Fix backend integration test regressions

### DIFF
--- a/backend/src/api/channels.rs
+++ b/backend/src/api/channels.rs
@@ -17,21 +17,15 @@ use crate::models::{
     normalize_avatar_url, Channel, ChannelMember, ChannelType, CreateChannel, UpdateChannel,
 };
 use crate::realtime::events::{EventType, WsBroadcast, WsEnvelope};
-use crate::repositories::{AdminRepository, ChannelRepository, UserRepository};
+use crate::repositories::{ChannelRepository, UserRepository};
 
 /// Check if user is channel creator, admin, or has system manage permission
 async fn is_channel_creator_or_admin(
     state: &AppState,
     channel_id: Uuid,
-    user_id: Uuid,
+    auth: &AuthUser,
 ) -> ApiResult<bool> {
-    // Check system manage permission first
-    let has_system_manage = AdminRepository::new(&state.db)
-        .has_system_manage_permission(user_id)
-        .await
-        .map_err(|e| AppError::Internal(e.to_string()))?;
-
-    if has_system_manage {
+    if auth.has_permission(&permissions::SYSTEM_MANAGE) {
         return Ok(true);
     }
 
@@ -40,13 +34,13 @@ async fn is_channel_creator_or_admin(
         .get_creator_id(channel_id)
         .await?;
 
-    if creator_id == Some(user_id) {
+    if creator_id == Some(auth.user_id) {
         return Ok(true);
     }
 
     // Check if user is channel admin
     let role: Option<String> = ChannelRepository::new(&state.db)
-        .get_member_role(channel_id, user_id)
+        .get_member_role(channel_id, auth.user_id)
         .await?;
 
     let is_admin = matches!(
@@ -349,7 +343,7 @@ async fn update_channel(
     Json(input): Json<UpdateChannel>,
 ) -> ApiResult<Json<Channel>> {
     // Check if user is creator or admin
-    let can_update = is_channel_creator_or_admin(&state, id, auth.user_id).await?;
+    let can_update = is_channel_creator_or_admin(&state, id, &auth).await?;
 
     if !can_update {
         return Err(AppError::Forbidden(
@@ -404,7 +398,7 @@ async fn delete_channel(
     Path(id): Path<Uuid>,
 ) -> ApiResult<Json<serde_json::Value>> {
     // Check if user is creator or admin
-    let can_delete = is_channel_creator_or_admin(&state, id, auth.user_id).await?;
+    let can_delete = is_channel_creator_or_admin(&state, id, &auth).await?;
 
     if !can_delete {
         return Err(AppError::Forbidden(

--- a/backend/src/models/activity.rs
+++ b/backend/src/models/activity.rs
@@ -79,6 +79,16 @@ pub struct MarkReadRequest {
 }
 
 impl ActivityType {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            ActivityType::Mention => "mention",
+            ActivityType::Reply => "reply",
+            ActivityType::Reaction => "reaction",
+            ActivityType::Dm => "dm",
+            ActivityType::ThreadReply => "thread_reply",
+        }
+    }
+
     /// Parse activity type from string
     pub fn parse(s: &str) -> Option<Self> {
         match s {

--- a/backend/src/repositories/channel_repository.rs
+++ b/backend/src/repositories/channel_repository.rs
@@ -616,6 +616,7 @@ impl<'a> ChannelRepository<'a> {
                 c.creator_id,
                 c.created_at,
                 c.updated_at,
+                c.deleted_at,
                 t.display_name AS team_display_name,
                 t.name AS team_name,
                 t.updated_at AS team_updated_at

--- a/backend/src/services/activity.rs
+++ b/backend/src/services/activity.rs
@@ -54,17 +54,17 @@ pub async fn create_activity(
     message_text: Option<String>,
     reaction: Option<String>,
 ) -> ApiResult<Activity> {
-    let activity: Activity = sqlx::query_as(
+    let row = sqlx::query(
         r#"
         INSERT INTO activities
             (user_id, type, actor_id, channel_id, team_id, post_id, root_id, message_text, reaction)
         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
-        RETURNING id, user_id, type as "type: ActivityType", actor_id, channel_id, team_id,
+        RETURNING id, user_id, type as activity_type, actor_id, channel_id, team_id,
                   post_id, root_id, message_text, reaction, read, created_at
         "#,
     )
     .bind(user_id)
-    .bind(activity_type)
+    .bind(activity_type.as_str())
     .bind(actor_id)
     .bind(channel_id)
     .bind(team_id)
@@ -74,6 +74,21 @@ pub async fn create_activity(
     .bind(reaction)
     .fetch_one(&state.db)
     .await?;
+    let activity = Activity {
+        id: row.get("id"),
+        user_id: row.get("user_id"),
+        r#type: ActivityType::parse(&row.get::<String, _>("activity_type"))
+            .expect("unknown activity type"),
+        actor_id: row.get("actor_id"),
+        channel_id: row.get("channel_id"),
+        team_id: row.get("team_id"),
+        post_id: row.get("post_id"),
+        root_id: row.get("root_id"),
+        message_text: row.get("message_text"),
+        reaction: row.get("reaction"),
+        read: row.get("read"),
+        created_at: row.get("created_at"),
+    };
 
     // Fetch full ActivityResponse for broadcast (includes joined actor/channel/team data)
     let activity_response: Option<ActivityResponse> = sqlx::query(

--- a/backend/tests/service_posts.rs
+++ b/backend/tests/service_posts.rs
@@ -90,7 +90,7 @@ async fn setup_context() -> TestContext {
 
     let sender_id = sender_me["id"]
         .as_str()
-        .and_then(|s| uuid::Uuid::parse_str(s).ok())
+        .and_then(parse_mm_or_uuid)
         .expect("sender id should parse");
 
     let receiver_username = format!("receiver_{}", &Uuid::new_v4().to_string()[..8]);
@@ -142,7 +142,7 @@ async fn setup_context() -> TestContext {
 
     let receiver_id = receiver_me["id"]
         .as_str()
-        .and_then(|s| uuid::Uuid::parse_str(s).ok())
+        .and_then(parse_mm_or_uuid)
         .expect("receiver id should parse");
 
     let team_id = Uuid::new_v4();
@@ -376,12 +376,19 @@ async fn create_post_mentions_triggers_notification() {
     );
 
     let activities = activity_res["activities"]
-        .as_array()
-        .expect("activities should be array");
-    let mention_activity = activities.iter().find(|a| {
-        a["type"] == "mention"
-            && a["actor_id"].as_str() == Some(&encode_mm_id(ctx.sender_id))
-            && a["post_id"].as_str() == Some(post_id)
+        .as_object()
+        .expect("activities should be keyed by activity id");
+    let mention_activity = activities.values().find(|a| {
+        let actor_matches = a["actor_id"]
+            .as_str()
+            .and_then(parse_mm_or_uuid)
+            .is_some_and(|id| id == ctx.sender_id);
+        let post_matches = a["post_id"]
+            .as_str()
+            .and_then(parse_mm_or_uuid)
+            .is_some_and(|id| id == post_uuid);
+
+        a["type"] == "mention" && actor_matches && post_matches
     });
 
     assert!(

--- a/backend/tests/service_unreads.rs
+++ b/backend/tests/service_unreads.rs
@@ -1,7 +1,7 @@
 #![allow(dead_code)]
 #![allow(clippy::needless_borrows_for_generic_args)]
 use crate::common::spawn_app;
-use rustchat::mattermost_compat::id::encode_mm_id;
+use rustchat::mattermost_compat::id::{encode_mm_id, parse_mm_or_uuid};
 use serde_json::json;
 use uuid::Uuid;
 
@@ -77,7 +77,7 @@ async fn setup_context() -> TestContext {
 
     let sender_id = sender_me["id"]
         .as_str()
-        .and_then(|s| uuid::Uuid::parse_str(s).ok())
+        .and_then(parse_mm_or_uuid)
         .expect("sender id should parse");
 
     // Register receiver
@@ -129,7 +129,7 @@ async fn setup_context() -> TestContext {
 
     let receiver_id = receiver_me["id"]
         .as_str()
-        .and_then(|s| uuid::Uuid::parse_str(s).ok())
+        .and_then(parse_mm_or_uuid)
         .expect("receiver id should parse");
 
     // Create team and channel


### PR DESCRIPTION
## Summary
- use the authenticated user's policy role for v1 channel update/delete permission checks instead of querying a missing roles table
- include deleted_at in the all-channels query row used by the v4 channel mapper
- persist activity types as varchar values so mention activities are written, and align integration tests with Mattermost-compatible IDs/activity feed shape

## Verification
- docker compose -f docker-compose.integration.yml up -d
- RUSTCHAT_TEST_DATABASE_URL=postgres://rustchat:rustchat@127.0.0.1:55432/rustchat RUSTCHAT_TEST_REDIS_URL=redis://127.0.0.1:56379/ RUSTCHAT_TEST_S3_ENDPOINT=http://127.0.0.1:59000 RUSTCHAT_TEST_S3_ACCESS_KEY=testaccesskey RUSTCHAT_TEST_S3_SECRET_KEY=testsecretkey RUSTCHAT_TEST_S3_BUCKET=test-bucket DATABASE_URL=postgres://rustchat:rustchat@127.0.0.1:55432/rustchat cargo test --no-fail-fast --test api_permissions --test api_v4_channels_all --test service_posts --test service_unreads -- --nocapture