### PR TITLE
Fix nightly reusable workflow validation

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -18,7 +18,6 @@ jobs:
   ci:
     name: CI
     uses: ./.github/workflows/ci.yml
-    timeout-minutes: 60
 
   nightly-tag:
     name: Generate nightly tag


### PR DESCRIPTION
## Summary
- remove unsupported timeout-minutes from the nightly job that calls the reusable CI workflow

## Validation
- git diff --check
- parsed .github/workflows/nightly.yml with Python YAML loader