### PR TITLE
Allow nightly workflow to call CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,12 @@ on:
         description: 'GitHub runner label to run the jobs on'
         type: string
         default: 'self-hosted'
+  workflow_call:
+    inputs:
+      runner:
+        description: 'GitHub runner label to run the jobs on'
+        type: string
+        default: 'self-hosted'
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary
- add workflow_call support to CI so nightly can run the reusable CI gate before publishing images

## Validation
- git diff --check
- parsed ci.yml and nightly.yml with Python YAML loader
- manual nightly dispatch exposed the missing workflow_call trigger this fixes