### PR TITLE
fix: handle channel update duplicate name and not-found errors

### DIFF
--- a/backend/src/repositories/channel_repository.rs
+++ b/backend/src/repositories/channel_repository.rs
@@ -300,8 +300,8 @@ impl<'a> ChannelRepository<'a> {
         display_name: Option<&str>,
         purpose: Option<&str>,
         header: Option<&str>,
-    ) -> Result<Channel, sqlx::Error> {
-        sqlx::query_as(
+    ) -> ApiResult<Channel> {
+        let result = sqlx::query_as(
             r#"
             UPDATE channels SET
                 name = COALESCE($2, name),
@@ -319,7 +319,24 @@ impl<'a> ChannelRepository<'a> {
         .bind(purpose)
         .bind(header)
         .fetch_one(self.pool)
-        .await
+        .await;
+
+        match result {
+            Ok(channel) => Ok(channel),
+            Err(sqlx::Error::RowNotFound) => Err(AppError::ChannelNotFound),
+            Err(e) => {
+                if let Some(db_err) = e.as_database_error() {
+                    if let Some(constraint) = db_err.constraint() {
+                        if constraint.contains("channels_name_team_unique") {
+                            return Err(AppError::Conflict(
+                                "Channel name already exists in this team".to_string(),
+                            ));
+                        }
+                    }
+                }
+                Err(AppError::Database(e))
+            }
+        }
     }
 
     /// Soft delete a channel

--- a/backend/tests/api_permissions.rs
+++ b/backend/tests/api_permissions.rs
@@ -444,3 +444,111 @@ async fn add_channel_member(app: &common::TestApp, channel_id: Uuid, user_id: Uu
     .await
     .expect("failed to add channel member");
 }
+
+#[tokio::test]
+async fn update_channel_duplicate_name_returns_conflict() {
+    let app = spawn_app().await;
+    let org_id = insert_org(&app, "Conflict Org").await;
+    let (token, user_id) = register_and_login(
+        &app,
+        org_id,
+        "conflict_user",
+        "conflict_user@example.com",
+        None,
+    )
+    .await;
+
+    let team_id = insert_team(&app, org_id, "conflict-team").await;
+    add_team_member(&app, team_id, user_id, "member").await;
+
+    let channel1_id = insert_channel(&app, team_id, user_id, "channel-one").await;
+    let channel2_id = insert_channel(&app, team_id, user_id, "channel-two").await;
+    add_channel_member(&app, channel1_id, user_id, "admin").await;
+    add_channel_member(&app, channel2_id, user_id, "admin").await;
+
+    let response = app
+        .api_client
+        .put(format!("{}/api/v1/channels/{}", app.address, channel1_id))
+        .header("Authorization", format!("Bearer {token}"))
+        .json(&serde_json::json!({
+            "name": "channel-two"
+        }))
+        .send()
+        .await
+        .expect("channel update request should complete");
+
+    assert_eq!(response.status(), StatusCode::CONFLICT);
+}
+
+#[tokio::test]
+async fn v4_update_channel_duplicate_name_returns_conflict() {
+    let app = spawn_app().await;
+    let org_id = insert_org(&app, "V4 Conflict Org").await;
+    let (token, user_id) = register_and_login(
+        &app,
+        org_id,
+        "v4_conflict_user",
+        "v4_conflict_user@example.com",
+        None,
+    )
+    .await;
+
+    let team_id = insert_team(&app, org_id, "v4-conflict-team").await;
+    add_team_member(&app, team_id, user_id, "member").await;
+
+    let channel1_id = insert_channel(&app, team_id, user_id, "v4-channel-one").await;
+    let channel2_id = insert_channel(&app, team_id, user_id, "v4-channel-two").await;
+    add_channel_member(&app, channel1_id, user_id, "admin").await;
+    add_channel_member(&app, channel2_id, user_id, "admin").await;
+
+    let response = app
+        .api_client
+        .put(format!("{}/api/v4/channels/{}", app.address, channel1_id))
+        .header("Authorization", format!("Bearer {token}"))
+        .json(&serde_json::json!({
+            "name": "v4-channel-two"
+        }))
+        .send()
+        .await
+        .expect("v4 channel update request should complete");
+
+    assert_eq!(response.status(), StatusCode::CONFLICT);
+}
+
+#[tokio::test]
+async fn v4_patch_channel_duplicate_name_returns_conflict() {
+    let app = spawn_app().await;
+    let org_id = insert_org(&app, "V4 Patch Conflict Org").await;
+    let (token, user_id) = register_and_login(
+        &app,
+        org_id,
+        "v4_patch_conflict_user",
+        "v4_patch_conflict_user@example.com",
+        None,
+    )
+    .await;
+
+    let team_id = insert_team(&app, org_id, "v4-patch-conflict-team").await;
+    add_team_member(&app, team_id, user_id, "member").await;
+
+    let channel1_id = insert_channel(&app, team_id, user_id, "v4-patch-channel-one").await;
+    let channel2_id = insert_channel(&app, team_id, user_id, "v4-patch-channel-two").await;
+    add_channel_member(&app, channel1_id, user_id, "admin").await;
+    add_channel_member(&app, channel2_id, user_id, "admin").await;
+
+    let response = app
+        .api_client
+        .put(format!(
+            "{}/api/v4/channels/{}/patch",
+            app.address, channel1_id
+        ))
+        .header("Authorization", format!("Bearer {token}"))
+        .json(&serde_json::json!({
+            "name": "v4-patch-channel-two"
+        }))
+        .send()
+        .await
+        .expect("v4 channel patch request should complete");
+
+    assert_eq!(response.status(), StatusCode::CONFLICT);
+}


### PR DESCRIPTION
## What does this PR do?

Fixes HTTP 500 errors when saving changes to a channel. Previously, any database failure during channel update (e.g. duplicate name constraint violation) bubbled up as an unhandled 500 Internal Server Error.

## Area affected

- [x] backend

## Does this change public behavior or API contracts?

- [x] Yes — describe: Channel update endpoints now return 409 Conflict for duplicate channel names within a team, and 404 NotFound when the channel does not exist (was 500).

## Risk tier

- [x] elevated — auth, permissions, API behavior, schema, compat paths

## Tests

- [x] Added

## Docs / ADR

- [x] Not needed

## Dependency Changes

- [x] Frontend dependencies unchanged

## Decision note (required for elevated and architectural changes)

ChannelRepository::update() now returns ApiResult<Channel> instead of Result<Channel, sqlx::Error>. This follows the pattern already used by other repository methods (create, update_privacy, restore, etc.) and enables proper error translation at the repository boundary rather than in every handler.

## DCO Sign-off

- [x] I signed off my commits with `git commit -s`

## Agent-generated

- [x] Yes — `Generated-by: Kimi Code CLI`, `Skill used: investigate`