### PR TITLE
fix(frontend): make markdown library import robust in Vitest/CI

### DIFF
--- a/frontend/src/composables/useMarkdownRenderer.test.ts
+++ b/frontend/src/composables/useMarkdownRenderer.test.ts
@@ -5,7 +5,8 @@ describe('useMarkdownRenderer XSS corpus', () => {
   const { renderMarkdown, isReady } = useMarkdownRenderer()
 
   beforeAll(async () => {
-    await vi.waitFor(() => isReady.value === true, { timeout: 5000 })
+    // Markdown libs are loaded asynchronously; give slow CI runners plenty of time.
+    await vi.waitFor(() => isReady.value === true, { timeout: 30000 })
   })
 
   it('removes script tags', () => {

--- a/frontend/src/composables/useMarkdownRenderer.ts
+++ b/frontend/src/composables/useMarkdownRenderer.ts
@@ -46,13 +46,17 @@ async function loadMarkdownLibs(): Promise<void> {
 
   isLoading = true
   try {
-    const [{ marked }, hljsModule] = await Promise.all([
+    const [markedModule, hljsModule] = await Promise.all([
       import('marked'),
       import('highlight.js/lib/common'),
     ])
 
+    // Handle both ESM named export and default export shapes across Vitest/CI environments.
+    const marked = markedModule.marked ?? (markedModule as any).default ?? (markedModule as any)
+    const hljs = hljsModule.default ?? (hljsModule as any)
+
     markedInstance = marked
-    hljsInstance = hljsModule.default
+    hljsInstance = hljs
 
     // Configure marked with syntax highlighting
     const renderer = new marked.Renderer()


### PR DESCRIPTION
Fixes the remaining Frontend Check failure where dynamic imports of `marked` and `highlight.js` resolved with an undefined named export in CI, causing "Cannot read properties of undefined (reading 'Renderer')" and falling back to escaped HTML.\n\nThe loader now accepts named, default, or module-as-object shapes, so the XSS sanitization tests run consistently across environments.\n\nLocal run: `npm run test:unit` → 300 passed.