### PR TITLE
docs: update docs for AI Agents and release v0.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.1] - 2026-06-19
+
 ### Added
-- AI Agents documentation covering channel-participant agents, the Agent Runtime, LLM provider setup, RAG knowledge bases, tool calling, feedback, analytics, and operational guidance.
-- Admin guide for creating agents, assigning them to channels, configuring knowledge bases, using RustShare sync sources, and monitoring agent behavior.
+- AI Agents & Ecosystem feature support: Channel-participant AI agents with LLM providers (GPT models), optional tools integration (Tavily search), pgvector search for RAG knowledge bases, RustShare sync sources, and user feedback tracking (thumbs up/down).
+- Comprehensive AI Agents administration documentation and runtime integration guidance.
+- Standard Bot accounts creation and management documentation.
+- Docker Compose quickstart troubleshooting tips and S3 private bucket security configuration guidance.
 
 ### Changed
-- Architecture, user, security, and runbook docs now describe the AI Agents phases and the optional runtime dependencies required to operate them safely.
+- Refactored and expanded Architecture, User, Security, and Runbook documents to detail the new AI Agents module, PGVector requirements, and optional runtime flags.
+
+### Fixed
+- Include `client_msg_id` in v1 channel posts list queries so message history loads instead of returning HTTP 500.
 
 ### Security
 - Default environment is now `production`; permissive development CORS is gated by `RUSTCHAT_ALLOW_DEV_CORS` and rejected in production.
@@ -21,11 +28,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Outgoing webhook and slash-command URLs are validated at creation time and resolved/validated at request time, with redirects disabled, to prevent DNS-rebinding SSRF.
 - Retention cleanup now deletes S3 objects and includes an optional orphan scanner configured by `RUSTCHAT_RETENTION_ORPHAN_SCAN_*` environment variables.
 - Frontend container now runs as the non-root `rustchat` user.
-
-## [0.5.1] - 2026-06-12
-
-### Fixed
-- Include `client_msg_id` in v1 channel posts list queries so message history loads instead of returning HTTP 500.
 
 ## [0.5.0] - 2026-06-10
 

--- a/README.md
+++ b/README.md
@@ -81,6 +81,12 @@ RustChat gives your team everything needed for productive communication:
 - **Screen sharing** — Share your screen during calls
 - **Mobile ringing** — VoIP push notifications for incoming calls on mobile
 
+### AI Agents & Ecosystem
+- **AI Agents** — Custom AI assistants acting as native channel participants responding to mentions or all messages
+- **RAG Knowledge Bases** — Sync documents from S3 or external folders (via RustShare) with PGVector semantic search indexing
+- **Tavily Web Search Tool** — Operators can enable server-side web search tool capabilities for agents
+- **Agent Analytics & Feedback** — Detailed admin reporting on agent usage, cost, token volumes, and user-submitted feedback (thumbs up/down)
+
 ### Productivity
 - **Powerful search** — Find messages, files, and conversations instantly
 - **Keyboard shortcuts** — Navigate without leaving your keyboard (`Ctrl+K` for quick switcher)
@@ -113,13 +119,15 @@ RustChat is designed as three focused services working together:
       └──────────┘      └──────────┘      └──────────────┘
 ```
 
-**The Backend** — A Rust service handling REST APIs, WebSocket connections, and business logic. It speaks two protocols:
-- `/api/v1/*` — Native API for the web client
+**The Backend** — A Rust service handling REST APIs, WebSocket connections, business logic, and the **Agent Runtime** for processing AI assistant workflows (supporting LLM completions, Tavily tools, and analytics). It speaks two protocols:
+- `/api/v1/*` — Native API for the web client (including `/api/v1/agents` CRUD and analytics)
 - `/api/v4/*` — Mattermost-compatible API for mobile and desktop clients
 
-**The Frontend** — A Vue.js single-page application that works in any modern browser. No Electron, no desktop installers.
+**The Frontend** — A Vue.js single-page application that works in any modern browser. No Electron, no desktop installers. Includes the Admin Console configuration interface for managing agents, knowledge bases, and sync settings.
 
 **The Push Proxy** — A dedicated service for mobile push notifications (FCM for Android, APNS for iOS).
+
+**PostgreSQL** — Primary data store. Enabled with the `pgvector` extension, it performs semantic vector indexing and retrieval for agent RAG knowledge bases.
 
 ---
 
@@ -283,6 +291,13 @@ See [Development Guide](docs/development.md) for the full setup, testing, and tr
 - Mobile app support (Mattermost mobile apps)
 - Push notifications
 
+### AI Agents & Ecosystem ✅
+- AI Agent runtime with OpenAI (or custom model overrides) integration
+- Knowledge Bases synced via S3 or local folders (RustShare)
+- pgvector semantic search indexing and retrieval (RAG)
+- Server-side tool execution support (Tavily Web Search)
+- Detailed Admin analytics and user feedback collection (thumbs up/down)
+
 See [What rustchat Cannot (Yet) Do](#limitations) for known gaps.
 
 ---
@@ -297,7 +312,7 @@ We believe in honest communication about capabilities:
 - **Advanced post actions** — Some Mattermost compatibility actions return explicit `501` until RustChat implements matching behavior
 - **Custom Profile Attributes** — UI exists but backend is limited
 - **OAuth Apps** — Basic structure, not full marketplace
-- **Bots** — Framework present, limited bot management
+- **Bots** — Standard bot accounts with API tokens are fully supported; advanced bot management and marketplace integrations are limited
 
 ### Known Limits
 - **Calls** — Control plane scales via Redis; media plane is instance-local (no distributed SFU mesh)

--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -3993,7 +3993,7 @@ dependencies = [
 
 [[package]]
 name = "rustchat"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "aes",
  "aes-gcm",

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustchat"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2021"
 rust-version = "1.95"
 authors = ["rustchat contributors"]

--- a/docs/admin/ai-agents.md
+++ b/docs/admin/ai-agents.md
@@ -29,14 +29,42 @@ For RAG:
 CREATE EXTENSION IF NOT EXISTS vector;
 ```
 
-## Create an Agent
+## Create and Configure an Agent
 
-1. Open **Admin Console > AI Agents**.
-2. Create an agent with a display name, username, model, system prompt, temperature, and context limits.
-3. Review the generated API key if your deployment uses agent-to-agent or external agent calls.
-4. Save the agent.
+To create a new AI Agent, navigate to **Admin Console > AI Agents** and click **Create Agent**. The configuration is divided into four main tabs:
 
-Agents are stored as normal RustChat users with `entity_type = 'agent'`. They appear in channel membership and post authorship using their configured profile.
+### 1. Basic Details
+* **Username**: The unique handle for the agent (e.g. `support-bot`). The username must be unique, lowercase alphanumeric with dashes/underscores, and is used for `@mentions`.
+* **Email**: A valid email address mapped to this agent account.
+* **Display Name**: (Optional) The public-facing name shown in chat threads.
+* **Title**: A short title indicating the agent's role (e.g., *Customer Support AI*).
+* **Description**: (Optional) Admin-facing notes about the agent's purpose.
+
+### 2. LLM Provider Options
+* **Provider**: Select from `OpenAI`, `Anthropic`, or `Ollama`.
+* **Model**: Specify the target model ID (e.g., `gpt-4o-mini`, `claude-3-5-sonnet-20241022`, or local Ollama tags).
+* **API Token**: (Optional) Override credentials for this specific agent. If left blank, the system-wide environment variables (e.g., `RUSTCHAT_OPENAI_API_KEY`) are utilized.
+* **Temperature**: Controls response randomness (range `0.0` to `2.0`). Recommended `0.3` for grounded tasks and `0.7` for general conversation.
+* **Max Output Tokens**: Limits the response token length (e.g., `1024`).
+
+### 3. Behavior & Capabilities
+* **System Prompt**: Core instructions defining the agent's persona, boundaries, response style, and instructions.
+* **Max Context Messages**: The maximum number of historical messages in the conversation channel sent as context to the LLM (default `10`).
+* **Capabilities**:
+  * **Respond to Mentions**: When checked, the agent replies when explicitly `@mentioned` in channels.
+  * **Respond to All**: When checked, the agent processes and replies to *every* new message in assigned channels.
+  * **Use Memory**: Enables the agent to maintain basic message history/memory.
+  * **Use RAG**: Allows the agent to query assigned knowledge bases.
+* **RAG Settings**:
+  * **RAG Enabled**: (Toggle) Explicitly enable Retrieval-Augmented Generation.
+  * **RAG Top-K**: Number of relevant document chunks retrieved during semantic vector search queries (default `5`).
+
+### 4. Channels
+* Select which channels the agent is active in. Agents can only participate in, read, or reply to channels they are explicitly added to.
+
+---
+
+Agents are stored as normal RustChat users with `entity_type = 'agent'`. They appear in channel membership lists and post authorship using their configured profiles. If your deployment uses external agent calls or agent-to-agent (a2a) communication, you can retrieve the agent's generated API key from the agent detail view.
 
 ## Assign Agents to Channels
 

--- a/docs/architecture/backend.md
+++ b/docs/architecture/backend.md
@@ -14,20 +14,22 @@ The backend is built with:
 
 ```
 backend/src/
-├── api/              # HTTP handlers
+├── a2a/              # Agent-to-agent communication layer
+├── api/              # HTTP handlers (including v1/agents.rs)
 │   ├── v1/          # Native API
 │   └── v4/          # Mattermost-compatible API
 ├── auth/            # Authentication & JWT
 ├── config/          # Environment configuration
 ├── db/              # Database connection & migrations
 ├── error/           # Error types
-├── jobs/            # Background workers
+├── jobs/            # Background workers (including sync & RAG ingestion)
 ├── mattermost_compat/  # MM compatibility utilities
 ├── middleware/      # Axum middleware
-├── models/          # Data models
+├── models/          # Data models (User with entity_type='agent', AgentConfig, Knowledge, etc.)
 ├── realtime/        # WebSocket hub
-├── services/        # Business logic
-├── storage/         # S3 file storage
+├── repositories/    # Database access repositories (AgentRepository, AgentFeedbackRepository, etc.)
+├── services/        # Business logic (including llm/ completions and agents CRUD)
+├── storage/         # S3 file storage & knowledge ingestion
 └── telemetry/       # Logging & tracing
 ```
 
@@ -65,6 +67,8 @@ One service per domain:
 - `post_service` - Message operations
 - `file_service` - File uploads
 - `user_service` - User management
+- `agent_service` - AI Agents management and channel dispatcher logic
+- `llm_service` - OpenAI connection, RAG prompting, and context truncation logic
 
 ### Database Access
 

--- a/docs/repo-current-state.md
+++ b/docs/repo-current-state.md
@@ -1,7 +1,7 @@
 # Repo Current State
 
-**Last updated:** 2026-06-16
-**Version:** v0.5.0
+**Last updated:** 2026-06-19
+**Version:** v0.5.1
 
 > This document describes the state of the repository as of its last update. For live issue tracking see GitHub Issues.
 
@@ -9,11 +9,12 @@
 
 ## 1. Version
 
-**Current:** v0.5.0
+**Current:** v0.5.1
 
-Version is synchronized across two files:
+Version is synchronized across three files:
 - `backend/Cargo.toml` → `[package] version`
 - `frontend/package.json` → `"version"`
+- `push-proxy/Cargo.toml` → `[package] version`
 
 To check: `grep '^version' backend/Cargo.toml` or `jq .version frontend/package.json`
 
@@ -73,6 +74,7 @@ For live in-flight work see [GitHub Issues](https://github.com/rustchatio/rustch
 | Governance Layer | `.governance/` policy files, CODEOWNERS, PR template, issue forms, branch protection, GitHub labels | 2026-03-22 |
 | Foundation Docs | 7 structured docs consolidating existing flat docs | 2026-03-22 |
 | P0 Production Readiness | Security/operations hardening alignment, runbook fixes, and doc/env alignment | 2026-06-16 |
+| AI Agents & Ecosystem | Introduce AI Agents runtime, RAG pgvector capabilities, Tavily web tools, feedback APIs, bot guide, and v0.5.1 alignment | 2026-06-19 |
 
 ---
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,7 +2,7 @@
   "name": "frontend",
   "private": true,
   "license": "Apache-2.0",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "engines": {
     "node": ">=24.0.0"
   },

--- a/push-proxy/Cargo.toml
+++ b/push-proxy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "push-proxy"
-version = "0.1.0"
+version = "0.5.1"
 edition = "2024"
 rust-version = "1.95"
 license = "Apache-2.0"


### PR DESCRIPTION
Bumps backend, frontend, and push-proxy versions to 0.5.1 to align with VERSION. Updates main README.md, CHANGELOG.md, and docs/architecture/backend.md to document the newly introduced AI Agents & Ecosystem and RAG framework details. Ported issue fixes for standard bots, S3 bucket private access, and Node 24 requirement documentation.