### PR TITLE
fix(frontend): specify config extension and increase test timeout in vitest

### DIFF
--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -1,12 +1,13 @@
 import { fileURLToPath } from 'node:url'
 import { mergeConfig, defineConfig, configDefaults } from 'vitest/config'
-import viteConfig from './vite.config'
+import viteConfig from './vite.config.ts'
 
 export default mergeConfig(
   viteConfig,
   defineConfig({
     test: {
       environment: 'jsdom',
+      testTimeout: 15000,
       exclude: [...configDefaults.exclude, 'e2e/**', 'tests/**/*.spec.ts', '**/*.spec.ts'],
       root: fileURLToPath(new URL('./', import.meta.url)),
     },


### PR DESCRIPTION
## Description
- Adds explicit `.ts` extension to `./vite.config` import in [vitest.config.ts](file:///srv/data01/kubedo/rustchat/frontend/vitest.config.ts) to resolve Vite deprecation warning.
- Sets `testTimeout: 15000` in Vitest configuration to prevent test timeouts under heavy CPU/parallel test loads.

## Validation
- `npm run build` passed
- `npm run test:unit` passed (35/35 test suites, 246/246 tests)
- `npm run lint` passed
- `cargo fmt --check`, `cargo clippy`, and `cargo test --lib` passed