### PR TITLE
docs: reduce coding-agent context churn

### DIFF
--- a/.rgignore
+++ b/.rgignore
@@ -1,0 +1,41 @@
+# Search/context exclusions for coding agents and ripgrep.
+# Keep production source, migrations, governance, and compatibility specs searchable.
+
+target/
+node_modules/
+frontend/dist/
+frontend/coverage/
+docs/.vitepress/dist/
+docs/.vitepress/cache/
+coverage/
+test-results/
+playwright-report/
+blob-report/
+frontend/test-results/
+frontend/playwright-report/
+
+# Local agent/tool state
+.claude/
+.codex/
+.kimi/
+.agents/
+.agent.workflows/
+.agent.history/
+.agent.cache/
+.gstack/
+.worktrees/
+.sccache/
+
+# Generated compatibility/local output
+mattermost-mobile/
+tools/mm-compat/output/
+logs/
+.cache/
+
+# Noisy local artifacts
+*.log
+*.tmp
+*.temp
+*.bak
+*.profraw
+.DS_Store

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -119,3 +119,47 @@ git commit -s -m "feat: add channel search endpoint"
 ```
 
 DCO is enforced in CI; PRs with unsigned commits will fail the required check.
+
+## Agent Context and Token Efficiency
+
+Treat planning and execution as separate context phases. A planning agent may inspect architecture and cross-service boundaries as needed; once it identifies the affected area, the implementation agent must start from that bounded scope instead of rediscovering the repository.
+
+### Search and reading discipline
+
+- Prefer `rg`, `git grep`, targeted directory listings, and bounded file reads over recursive filesystem scans or broad source dumps.
+- Respect `.gitignore` and `.rgignore`. Do not search Rust `target/`, `node_modules/`, frontend/docs build output, coverage/Playwright reports, caches, worktrees, local Mattermost checkouts, generated compatibility output, or agent-tool state unless explicitly required.
+- Keep `.governance/**`, migrations, architecture docs, and compatibility specs searchable; they can define mandatory behavior and review boundaries.
+- Do not re-read unchanged files just to recover context. Use targeted reads and `git diff` after edits.
+- Avoid streaming large compiler/test/docker logs into model context. Capture noisy output and inspect the relevant error lines or a bounded tail.
+
+### Scope before execution
+
+Before editing, identify:
+
+- runtime area: `backend`, `push-proxy`, `frontend`, or offline compatibility tooling;
+- gated paths or required human review from `.governance/agent-contracts.yml`;
+- files/symbols expected to change;
+- smallest test set that proves the behavior;
+- external services needed, if any.
+
+Do not make a backend executor re-scan frontend or compatibility tooling when the plan already established that they are out of scope. Expand only when implementation or test evidence requires it.
+
+### Validation ladder
+
+Validate the changed runtime independently first:
+
+```bash
+# Backend: start with the smallest relevant unit/test target.
+cd backend
+cargo check
+cargo test --lib <relevant-test-or-module-filter>
+
+# Push proxy is a separate Cargo workspace.
+cd push-proxy
+cargo check
+cargo test <relevant-test-filter>
+```
+
+For frontend work, begin with the affected unit tests/type/build checks rather than starting the full stack or E2E environment. Start PostgreSQL/Redis/S3 and run backend integration tests only when the behavior requires those boundaries.
+
+After targeted validation succeeds, run the complete checks required by the existing **Build, Test, and Validation** section for every area touched. Context efficiency changes the order and repetition of checks; it never weakens CI, governance, security, compatibility, or final validation requirements.


### PR DESCRIPTION
## What changed

- added `.rgignore` for Rust/frontend/docs/test/cache/agent-tool output;
- extended `AGENTS.md` with explicit planning-vs-execution context boundaries;
- documented runtime-area-first validation for backend, push proxy, and frontend work;
- kept governance, migrations, architecture, and compatibility specs searchable and authoritative.

## Why

RustChat spans separate Rust workspaces, a Vue frontend, integration infrastructure, and Mattermost compatibility tooling. Agents should not rescan unrelated runtime areas or stream large integration/build output into context after the planner has already bounded the task.

## Impact

Developer/agent workflow only. No backend, push, frontend, migration, auth, compatibility, or API behavior changes.

## Validation

Compared `main...agent/rust-agent-context-hygiene`: only `AGENTS.md` and the new `.rgignore` changed. Existing area-specific CI checks, governance review gates, and integration requirements remain mandatory.